### PR TITLE
Index fix

### DIFF
--- a/panbox-common/src/org/panbox/desktop/common/gui/PanboxClientGUI.java
+++ b/panbox-common/src/org/panbox/desktop/common/gui/PanboxClientGUI.java
@@ -2546,7 +2546,7 @@ public class PanboxClientGUI extends javax.swing.JFrame {
 			public void actionPerformed(ActionEvent e) {
 				try {
 					int selected = shareList.getSelectedIndex();
-					if(selected < 0)
+					if (selected < 0)
 						return;
 					PanboxShare share = shareModel.getElementAt(selected);
 

--- a/panbox-common/src/org/panbox/desktop/common/gui/PanboxClientGUI.java
+++ b/panbox-common/src/org/panbox/desktop/common/gui/PanboxClientGUI.java
@@ -2546,6 +2546,8 @@ public class PanboxClientGUI extends javax.swing.JFrame {
 			public void actionPerformed(ActionEvent e) {
 				try {
 					int selected = shareList.getSelectedIndex();
+					if(selected < 0)
+						return;
 					PanboxShare share = shareModel.getElementAt(selected);
 
 					if (share instanceof DropboxPanboxShare) {


### PR DESCRIPTION
Clicking on add device in shares will result in a IndexOutOfBounds Exception if there are no shares.