### PR TITLE
Enforce case-sensitivity in VFS settings

### DIFF
--- a/panbox-win/src/net/decasdev/dokan/Dokan.java
+++ b/panbox-win/src/net/decasdev/dokan/Dokan.java
@@ -9,7 +9,6 @@
 package net.decasdev.dokan;
 
 import org.apache.log4j.Logger;
-import org.panbox.desktop.common.utils.DesktopApi;
 
 public class Dokan {
 
@@ -36,6 +35,10 @@ public class Dokan {
 	 * Driver something wrong
 	 */
 	public static final int DOKAN_START_ERROR = -4;
+	/**
+	 * Mount point is invalid 
+	 */
+	 public static final int DOKAN_MOUNT_POINT_ERROR= -6;
 	// mount returns error codes
 	public static final int DOKAN_SUCCESS = 0;
 
@@ -43,9 +46,9 @@ public class Dokan {
 		try {
 			System.loadLibrary("JDokan");
 		} catch (UnsatisfiedLinkError ex) {
+			// TODO: error handling
 			logger.fatal("Dokan : !!!Static construction while loading native library!!! : Exception: "
 					+ ex.getMessage());
-			System.exit(DesktopApi.EXIT_ERR_UNKNOWN);
 		}
 	}
 
@@ -83,6 +86,8 @@ public class Dokan {
 			return "Driver something wrong.";
 		case Dokan.DOKAN_MOUNT_ERROR:
 			return "Can't assign a drive letter.";
+		case Dokan.DOKAN_MOUNT_POINT_ERROR:
+			return "Mount point is invalid.";
 		default:
 			return "Unknown error.";
 		}

--- a/panbox-win/src/net/decasdev/dokan/DokanVolumeInformation.java
+++ b/panbox-win/src/net/decasdev/dokan/DokanVolumeInformation.java
@@ -24,7 +24,8 @@ public class DokanVolumeInformation {
         this.volumeName = volumeName;
         this.fileSystemName = fileSystemName;
         this.maximumComponentLength = maximumComponentLength;
-        volumeSerialNumber = serialNumber;
+        this.volumeSerialNumber = serialNumber;
+        this.fileSystemFlags = 0x00000001 | 0x00000002; //case-sensitive and case-is-preserved
     }
 
     @Override


### PR DESCRIPTION
This fixes a bug which occurred when using Paint, WordPad or Reader for example that the file name was interpreted as uppercase by the program.