### PR TITLE
Added WiX setup firewall extension

### DIFF
--- a/panbox-win/Setup/Product.wxs
+++ b/panbox-win/Setup/Product.wxs
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:fire="http://schemas.microsoft.com/wix/FirewallExtension">
 
   <?include "Settings.wxi" ?>
 
@@ -153,6 +154,9 @@
       </Component>
       <Component Id="panbox_win.jar">
         <File Source="$(var.DistDir)\panbox-win.jar" />
+        
+        <!-- Adjust local windows firewall in order to let PanBox access the local network ports for LAN pairing -->
+        <fire:FirewallException Id="panbox_firewall" Name="PanBox firewall exceptions" Program="[JreFolder]\bin\javaw.exe" Scope="localSubnet" />
       </Component>
       <Component Id="panbox_splashscreen.png">
         <File Source="$(var.DistDir)\panbox_splashscreen.png" />

--- a/panbox-win/Setup/Setup.wixproj
+++ b/panbox-win/Setup/Setup.wixproj
@@ -27,6 +27,12 @@
   <ItemGroup>
     <Content Include="Settings.wxi" />
   </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixFirewallExtension">
+      <HintPath>$(WixExtDir)\WixFirewallExtension.dll</HintPath>
+      <Name>WixFirewallExtension</Name>
+    </WixExtension>
+  </ItemGroup>
   <Import Project="$(WixTargetsPath)" />
   <PropertyGroup>
     <PreBuildEvent>cd $(SolutionDir)\..\..


### PR DESCRIPTION
Added WiX firewall extension to Windows PanBox setup in order to configure Windows firewall properly so that LAN pairing works without adjusting Windows firewall in an extra step.