### PR TITLE
Removed need of reboot after installation in WiX installer

### DIFF
--- a/panbox-win/Setup/Product.wxs
+++ b/panbox-win/Setup/Product.wxs
@@ -246,10 +246,6 @@
       <MergeRef Id="ATLRedist"/>                     <!-- Install ATL runtime environment -->
       <MergeRef Id="CRTRedist"/>                     <!-- Install C/C++ runtime environment -->
     </Feature>
-  
-    <InstallExecuteSequence>
-      <ScheduleReboot After="InstallFinalize"/>
-    </InstallExecuteSequence>  
 
   </Product>
 </Wix>


### PR DESCRIPTION
Since the server has been removed the reboot isn't needed anymore!