### PR TITLE
Fixed too long filenames on Windows

### DIFF
--- a/panbox-win/src/org/panbox/desktop/windows/vfs/DokanUserFS.java
+++ b/panbox-win/src/org/panbox/desktop/windows/vfs/DokanUserFS.java
@@ -218,6 +218,10 @@ public class DokanUserFS implements PanboxFSAdapter, DokanOperations {
 						+ " : onCreateFile : Exception: ", e);
 			}
 			throw new DokanOperationException(ERROR_FILE_NOT_FOUND);
+		} catch (FilenameExceededRangeException e) {
+			logger.debug(getClass().getName()
+					+ " : onCreateFile : Path including filename was too long on backend. Will return max filename length exceeded error. " + e.getMessage());
+			throw new DokanOperationException(ERROR_FILENAME_EXCED_RANGE);
 		} catch (Exception e) {
 			logger.error(getClass().getName()
 					+ " : onCreateFile : Unknown Exception: ", e);

--- a/panbox-win/src/org/panbox/desktop/windows/vfs/PanboxFSWindows.java
+++ b/panbox-win/src/org/panbox/desktop/windows/vfs/PanboxFSWindows.java
@@ -172,7 +172,7 @@ public class PanboxFSWindows extends PanboxFS {
 			int creationDisposition, int flagsAndAttributes,
 			boolean shareModeDeletable, boolean deleteOnClose,
 			DokanFileInfo fileInfo) throws PanboxCreateFailedException,
-			PathNotFoundException {
+			PathNotFoundException, FilenameExceededRangeException {
 		final FileCreationFlags disposition = fromDokan(creationDisposition);
 
 		logger.debug("PanboxFS : createFile : fileName: " + fileName
@@ -199,6 +199,11 @@ public class PanboxFSWindows extends PanboxFS {
 					@SuppressWarnings("resource")
 					// will be closed in close call!
 					VirtualRandomAccessFile file = (VirtualRandomAccessFile) virt;
+					
+					// Check if filename is too long for backend Windows path
+					if(file.getFile().getAbsolutePath().length() >= 255) {
+						throw new FilenameExceededRangeException( file.getFile().getAbsolutePath().length() );
+					}
 
 					if (!file.exists()) {
 						if (!getVirtualFileForFileName(


### PR DESCRIPTION
Fixed error in case the backend path was longer than 255 characters (bytes) on Windows machine. In this case a proper error message will be shown instead.