### PR TITLE
Adjusted startup script for Qubes OS support

### DIFF
--- a/panbox-linux/res/scripts/start.sh
+++ b/panbox-linux/res/scripts/start.sh
@@ -3,4 +3,4 @@ tty -s; if [ $? -ne 0 ]; then xterm -e "$0"; exit; fi
 SCRIPT=$(readlink -f "$0")
 jar_path=$(dirname "$SCRIPT")
 #optimization_flags="-server -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled -XX:PermSize=256M -XX:MaxPermSize=512M"
-java $optimization_flags -Djava.library.path=/usr/lib:/usr/lib/jni:/usr/lib64/libmatthew-java:/usr/share/libmatthew-java/lib -Dlogfile.location=$HOME/.panbox -Dlog4j.configuration=file:$jar_path/log4j.properties -jar $jar_path/panbox-linux.jar $*
+java $optimization_flags -Djava.library.path=/usr/lib:/usr/lib/jni:/usr/lib64/libmatthew-java:/usr/share/libmatthew-java/lib -Dlogfile.location=$HOME/.panbox -Dlog4j.configuration=file:$jar_path/log4j.properties -Djava.awt.headless=false -jar $jar_path/panbox-linux.jar $*


### PR DESCRIPTION
Adjusted start.sh so that headless mode is always set to false. This is needed for Linux distributions (e.g. Qubes OS), which does not support auto-detection of headless-mode.